### PR TITLE
Fixed indentation of headings and code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This repo contains a number of full-stack developer interview questions that can
 * What is a *servlet filter*? How to implement *GZipFilter*? (ResponseWrapper)
 * What is *generics* and PECS (producer extends and consumer super)?
 * What is *DAO* (Data Access Object)? (DAO allows one to switch between technologies like JDBC, Hibernate, JPA or JDO fairly easily)
-* What is the difference between <?> and <Object>?
+* What is the difference between <?> and \<Object\>?
 * XML: SAX, DOM, StAX
 
 ####[[⬆]](#toc) <a name='javascript'>Javascript:</a>
@@ -280,7 +280,7 @@ public static int lisSize(int[] a) {
 * How to find memory leak. (Memory snapshot diff).
 * Profiling: sampling and instrumentation.
 * Regular expressions. (Examples)
-* XPath* 
+* XPath 
 * What are your goals to work in our company? (3 categories: professional, financial, social)
 * What is *virtualization*? 
 * What is total/partial order?


### PR DESCRIPTION
208: Escaped the "<Object>" tag with "\"
283: Removed excess "*" after XPath that's causing the RSA codes to go out of bound